### PR TITLE
Support PNG images

### DIFF
--- a/tlassemble.m
+++ b/tlassemble.m
@@ -222,6 +222,7 @@ int main(int argc, const char *argv[]) {
     
     for (NSString *file in imageFiles) {
         if ([[file pathExtension] caseInsensitiveCompare:@"jpeg"] == NSOrderedSame ||
+	    [[file pathExtension] caseInsensitiveCompare:@"png"] == NSOrderedSame ||
             [[file pathExtension] caseInsensitiveCompare:@"jpg"] == NSOrderedSame) {
             imageCount++;
         }
@@ -259,6 +260,7 @@ int main(int argc, const char *argv[]) {
     for (NSString *file in imageFiles) {
         fullFilename = [inputPath stringByAppendingPathComponent:file];
         if ([[fullFilename pathExtension] caseInsensitiveCompare:@"jpeg"] == NSOrderedSame ||
+	    [[fullFilename pathExtension] caseInsensitiveCompare:@"png"] == NSOrderedSame ||
             [[fullFilename pathExtension] caseInsensitiveCompare:@"jpg"] == NSOrderedSame) {
             NSAutoreleasePool *innerPool = [[NSAutoreleasePool alloc] init];
             image = [[NSImage alloc] initWithContentsOfFile:fullFilename];


### PR DESCRIPTION
Greetings,
I use a rendering tool (DAZ Studio) to generate animations, and it outputs PNG files by default.  (Although strictly speaking tiff is also an option...)  I liked tlassemble for its simplicity, but I needed .png files processed.

Here's a simple pull request that worked for me.

--  Morgan
